### PR TITLE
Get posts form to save, enable description field

### DIFF
--- a/app/controllers/blogit/admin/posts_controller.rb
+++ b/app/controllers/blogit/admin/posts_controller.rb
@@ -47,7 +47,7 @@ module Blogit
 
       def update
         set_post_from_id(false)
-        if post.update_attributes(post_paramters)
+        if post.update_attributes(post_params)
           redirect_to post,
             notice: t(:blog_post_was_successfully_updated, scope: 'blogit.admin.posts')
         else
@@ -62,9 +62,9 @@ module Blogit
           notice: t(:blog_post_was_successfully_destroyed, scope: 'blogit.admin.posts')
       end
 
-      def post_paramters
+      def post_params
         if params[:post]
-          params.require(:post).permit(:title, :body, :tag_list, :state)
+          params.require(:post).permit(:title, :body, :tag_list, :state, :description)
         else
           {}
         end
@@ -91,7 +91,7 @@ module Blogit
       end
 
       def set_new_blogger_post_from_params
-        @post = current_blogger.blog_posts.new(post_paramters)
+        @post = current_blogger.blog_posts.new(post_params)
       end
 
     end

--- a/app/views/blogit/admin/posts/_form.html.erb
+++ b/app/views/blogit/admin/posts/_form.html.erb
@@ -18,15 +18,15 @@
     <%= f.text_field :title, \
       placeholder: t(:give_your_post_a_title, scope: 'blogit.admin.posts') %>
   <% end %>
-  
+
   <%= f.field do %>
     <%= f.label :description, t(:post_description, scope: "blogit.admin.posts") %>
     <%= f.text_area :description, \
-      placeholder: t(:write_a_brief_overview_of_your_post, 
+      placeholder: t(:write_a_brief_overview_of_your_post,
         scope: 'blogit.admin.posts') %>
   <% end %>
-  
-  <%= render "blogit/admin/posts/post_body_#{blogit_conf.admin_wysiwyg_editor}", 
+
+  <%= render "blogit/admin/posts/post_body_#{blogit_conf.admin_wysiwyg_editor}",
     { f: f } %>
 
   <%= f.field id: "new_blog_post_tag_field" do %>
@@ -37,15 +37,15 @@
 
   <%= f.field id: "new_blog_post_state_field" do %>
     <%= f.label :state, t(:state, scope: 'blogit.admin.posts') %>
-    <%= f.collection_select(:state, Blogit::Post::AVAILABLE_STATUS, :to_s, :to_s) %>
+    <%= f.collection_select(:state, (Blogit::Configuration::ACTIVE_STATES + Blogit::Configuration::HIDDEN_STATES), :to_s, :to_s) %>
   <% end %>
 
   <%= actions do %>
     <%= f.submit %> <%=t :or, scope: 'blogit.admin.posts'%>
-    
-    <%= link_to(t(:cancel, scope: 'blogit.admin.posts'), 
+
+    <%= link_to(t(:cancel, scope: 'blogit.admin.posts'),
       @post.new_record? ? blogit_admin.root_path : post_path(@post)) %>
-      
+
   <% end %>
 
 <% end %>

--- a/lib/blogit/admin/model_extensions/post.rb
+++ b/lib/blogit/admin/model_extensions/post.rb
@@ -4,19 +4,13 @@ module Blogit
       module Post
 
         extend ActiveSupport::Concern
-        
-        def description
-          "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-        end
-  
+
         module ClassMethods
 
           def for_admin_index(page_no)
             page(page_no).per(10)
           end
-    
         end
-        
       end
     end
   end

--- a/spec/controllers/blogit/comments_controller_spec.rb
+++ b/spec/controllers/blogit/comments_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Blogit::CommentsController do
+describe Blogit::CommentsController, type: :controller do
   
   let(:blog_post) { Blogit::Post.first || create(:post) }
     

--- a/spec/controllers/blogit/posts_controller_spec.rb
+++ b/spec/controllers/blogit/posts_controller_spec.rb
@@ -60,7 +60,7 @@ describe Blogit::PostsController do
 
       # TODO: Think of a way to test this. The PostsController is being cached
       # because cache-classes is set to true but that means the layout is not
-      # being changed. 
+      # being changed.
       #
       # This works in practice but not in testing
       # it "should use the specified layout" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
-  
+
   # =================
   # = Gem Factories =
   # =================
   factory :post, class: Blogit::Post do
-    title "Tis is a blog post title"
+    title "This is a blog post title"
     body "This is the body of the blog post - you'll see it's a lot bigger than the title"
     state "draft"
     association :blogger, :factory => :user
@@ -20,7 +20,7 @@ FactoryGirl.define do
     body "I once saw a child the size of a tangerine!"
     post
   end
-  
+
   # =======================
   # = Dummy App Factories =
   # =======================
@@ -28,5 +28,5 @@ FactoryGirl.define do
     username "bodacious"
     password "password"
   end
-  
+
 end


### PR DESCRIPTION
There were a couple of issues in order to get the form to successfully save, and also the description field just needed a couple of things in order to save.

I also went ahead and added the description in the factory.

Ship it!
